### PR TITLE
detect HTML code != 200 and log ERROR rather than creating fake downl…

### DIFF
--- a/wis2downloader/downloader/__init__.py
+++ b/wis2downloader/downloader/__init__.py
@@ -182,6 +182,12 @@ class DownloadWorker(BaseDownloader):
         response = None
         try:
             response = self.http.request('GET', _url)
+            # Check the response status code
+            if response.status != 200:
+                LOGGER.error(f"Error downloading {_url}, received status code: {response.status}")
+                # Increment failed download counter
+                FAILED_DOWNLOADS.labels(topic=topic, centre_id=centre_id).inc(1)
+                return
             # Get the filesize in KB
             filesize = len(response.data)
         except Exception as e:


### PR DESCRIPTION
Add checking and logging part so that wis2downloader now can detect HTML code != 200 and log ERROR rather than creating fake downloads:
<img width="968" alt="image" src="https://github.com/user-attachments/assets/a3ef17e9-2e45-4e80-b1cb-7f184d3be285">
<img width="1046" alt="image" src="https://github.com/user-attachments/assets/0c1ffccc-5729-4749-8c05-e9c64e2a9e8e">
